### PR TITLE
Fixes non specified version of algoliasearch in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages_data={'algoliasearchasync': ['resources/*.crt']},
     include_package_data=True,
     zip_safe=False,  # Because of the certificate
-    install_requires=['algoliasearch>=1.10.1', 'aiohttp>=2.0.5'],
+    install_requires=['algoliasearch>=1.10.1,<2.0', 'aiohttp>=2.0.5'],
     description='Algolia Search Asyncronous API Client for Python',
     long_description=README,
     author='Algolia Team',


### PR DESCRIPTION
This pull request addresses the fact that this package is not compatible with algoliasearch v2, adding `algoliasearch>=1.10.1,<2.0` to the requirements. 